### PR TITLE
Fixing a encoding bug appearing with python 3.7.2

### DIFF
--- a/mapper/emulation.py
+++ b/mapper/emulation.py
@@ -274,9 +274,9 @@ class EmulatedWorld(World):
 		direction = "".join(dir for dir in DIRECTIONS if dir.startswith(command))
 		if direction:
 			self.move(direction)
-		elif [method for method in userCommandsPartial if method.startswith(command)]:
-			completed = [method for method in userCommandsPartial if method.startswith(command)][0]
-			getattr(self, "user_command_partial_{}".format(completed))(arguments)
+		elif [method for method in userCommandsPartial if method.startswith(bytes(command, "us-ascii"))]:
+			completed = [method for method in userCommandsPartial if method.startswith(bytes(command, "us-ascii"))][0]
+			getattr(self, "user_command_partial_{}".format(completed.decode("us-ascii")))(arguments)
 		elif command in userCommands:
 			getattr(self, "user_command_{}".format(command))(arguments)
 		elif command.isdigit() or command in self.labels:


### PR DESCRIPTION
Hello Nick,

With python 3.7.2, the emulation is raising an encoding error when parsing the user input. This patch fixes it.

- I noticed that bug after I upgraded to python 3.7.2, but it may well be possible that I did not use the emulation with earlier versions of python 3.7, so, I don't know exactly on which version of python the bug appeared.
- There are several ways to handle the encoding conversion, but I don't know which one is the best. I just picked up one.
- The patch also works with python-2.7.15.
