### PR TITLE
path find

### DIFF
--- a/mapper/world.py
+++ b/mapper/world.py
@@ -866,7 +866,7 @@ class World(object):
 				similarLabels.sort(reverse=True, key=lambda label: fuzz.ratio(label, destination))
 				self.output("Unknown label. Did you mean "+", ".join(similarLabels[0:4])+"?")
 				return None
-		destinationRoom = self.rooms[destinationVnum]
+		destinationRoom = destinationVnum in self.rooms and self.rooms[destinationVnum]
 		if not origin or not destinationRoom:
 			self.output("Error: Invalid origin or destination.")
 			return None

--- a/mapper/world.py
+++ b/mapper/world.py
@@ -851,14 +851,21 @@ class World(object):
 		"""Find the path"""
 		if not origin:
 			origin = self.currentRoom
-		if destination and destination.strip().lower() in self.labels:
-			destination = self.labels[destination.strip().lower()]
-		if destination and destination in self.rooms:
-			destination = self.rooms[destination]
-		if not origin or not destination:
+		destination = destination.strip().lower()
+		try:
+			int(destination)  # just checking if this is an int
+			destinationVnum = destination
+		except ValueError:
+			if destination and destination in self.labels:
+				destinationVnum = self.labels[destination]
+			else:
+				self.output("Unknown label")
+				return None
+		destinationRoom = self.rooms[destinationVnum]
+		if not origin or not destinationRoom:
 			self.output("Error: Invalid origin or destination.")
 			return None
-		if origin is destination:
+		if origin is destinationRoom:
 			self.output("You are already there!")
 			return []
 		if flags:
@@ -866,7 +873,7 @@ class World(object):
 		else:
 			avoidTerrains = frozenset()
 		ignoreVnums = frozenset(("undefined", "death"))
-		isDestinationFunc = lambda currentRoomObj: currentRoomObj is destination  # NOQA: E731
+		isDestinationFunc = lambda currentRoomObj: currentRoomObj is destinationRoom  # NOQA: E731
 		exitIgnoreFunc = lambda exitObj: exitObj.to in ignoreVnums  # NOQA: E731
 		exitCostFunc = lambda exitObj, neighborRoomObj: (5 if "door" in exitObj.exitFlags or "climb" in exitObj.exitFlags else 0) + (1000 if "avoid" in exitObj.exitFlags else 0) + (10 if neighborRoomObj.terrain in avoidTerrains else 0)  # NOQA: E731
 		exitDestinationFunc = None

--- a/mapper/world.py
+++ b/mapper/world.py
@@ -854,8 +854,7 @@ class World(object):
 			origin = self.currentRoom
 		destination = destination.strip().lower()
 		try:
-			int(destination)  # just checking if this is an int
-			destinationVnum = destination
+			destinationVnum = str(abs(int(destination)))
 		except ValueError:
 			if destination and destination in self.labels:
 				destinationVnum = self.labels[destination]

--- a/mapper/world.py
+++ b/mapper/world.py
@@ -13,7 +13,7 @@ except ImportError:
 	from queue import Queue
 import re
 import threading
-from difflib import SequenceMatcher
+from fuzzywuzzy import fuzz
 
 from . import roomdata
 from .utils import regexFuzzy
@@ -861,7 +861,7 @@ class World(object):
 				destinationVnum = self.labels[destination]
 			else:
 				similarLabels = list(self.labels)
-				similarLabels.sort(reverse=True, key=lambda label: SequenceMatcher(None, label, destination).ratio())
+				similarLabels.sort(reverse=True, key=lambda label: fuzz.ratio(label, destination))
 				self.output("Unknown label. Did you mean "+", ".join(similarLabels[0:4])+"?")
 				return None
 		destinationRoom = self.rooms[destinationVnum]

--- a/mapper/world.py
+++ b/mapper/world.py
@@ -821,6 +821,7 @@ class World(object):
 				else:
 					speedWalkDirs.append("{0}{1}".format(lenGroup, direction[0]))
 			return speedWalkDirs
+		numDirections = len([d for d in directionsList  if d in DIRECTIONS])
 		result = []
 		directionsBuffer = []
 		while directionsList:
@@ -835,7 +836,7 @@ class World(object):
 		# Process any remaining items in the directions buffer.
 		if directionsBuffer:
 			result.extend(compressDirections(directionsBuffer))
-		return ", ".join(result)
+		return "{} rooms. {}".format(numDirections, ", ".join(result))
 
 	def path(self, *args):
 		if not args or not args[0]:

--- a/mapper/world.py
+++ b/mapper/world.py
@@ -13,6 +13,7 @@ except ImportError:
 	from queue import Queue
 import re
 import threading
+from difflib import SequenceMatcher
 
 from . import roomdata
 from .utils import regexFuzzy
@@ -859,7 +860,9 @@ class World(object):
 			if destination and destination in self.labels:
 				destinationVnum = self.labels[destination]
 			else:
-				self.output("Unknown label")
+				similarLabels = list(self.labels)
+				similarLabels.sort(reverse=True, key=lambda label: SequenceMatcher(None, label, destination).ratio())
+				self.output("Unknown label. Did you mean "+", ".join(similarLabels[0:4])+"?")
 				return None
 		destinationRoom = self.rooms[destinationVnum]
 		if not origin or not destinationRoom:

--- a/mapper/world.py
+++ b/mapper/world.py
@@ -732,6 +732,9 @@ class World(object):
 			self.output("Error: you need to supply a label.")
 			return None
 		label = matchDict["label"]
+		if label.isdecimal():
+			self.output("labels cannot be decimal values.")
+			return None
 		if matchDict["action"] == "add":
 			if not matchDict["vnum"]:
 				vnum = self.currentRoom.vnum

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 certifi
+fuzzywuzzy==0.17.0
 pyglet
+python-Levenshtein==0.12.0
 python-rapidjson
 # Note, if using py2exe and Python 2.7 to create a windows executable, an older version of Pyglet must be used.
 #pyglet==1.2.4


### PR DESCRIPTION
When a label that does not exist is passed into the pathFind function, output a list of labels with similar names to help the user with spelling.

If you would rather avoid adding the external dependancies, just scrap the last commit. The fix will still work, but with a simpler algorithm that returns adequate results, but not as good as the levenshtein results.