### PR TITLE
Emulation

### DIFF
--- a/mapper/main.py
+++ b/mapper/main.py
@@ -26,12 +26,13 @@ SB_REQUEST, SB_ACCEPTED, SB_REJECTED, SB_TTABLE_IS, SB_TTABLE_REJECTED, SB_TTABL
 
 
 class Proxy(threading.Thread):
-	def __init__(self, client, server, mapper):
+	def __init__(self, client, server, mapper, emulation=False):
 		threading.Thread.__init__(self)
 		self.name = "Proxy"
 		self._client = client
 		self._server = server
 		self._mapper = mapper
+		self.emulation = emulation
 		self.alive = threading.Event()
 
 	def close(self):
@@ -53,7 +54,7 @@ class Proxy(threading.Thread):
 				continue
 			if not data:
 				self.close()
-			elif data.strip() and data.strip().split()[0] in userCommands:
+			elif self.emulation or data.strip() and data.strip().split()[0] in userCommands:
 				self._mapper.queue.put((USER_DATA, data))
 			else:
 				try:
@@ -457,9 +458,10 @@ def main(
 		interface=interface,
 		promptTerminator=promptTerminator,
 		gagPrompts=gagPrompts,
-		findFormat=findFormat
+		findFormat=findFormat,
+		emulation=emulation,
 	)
-	proxyThread = Proxy(client=clientConnection, server=serverConnection, mapper=mapperThread)
+	proxyThread = Proxy(client=clientConnection, server=serverConnection, mapper=mapperThread, emulation=emulation)
 	serverThread = Server(
 		client=clientConnection,
 		server=serverConnection,

--- a/mapper/main.py
+++ b/mapper/main.py
@@ -361,6 +361,7 @@ class Server(threading.Thread):
 def main(
 		outputFormat,
 		interface,
+		emulation,
 		promptTerminator,
 		gagPrompts,
 		findFormat,

--- a/mapper/mapper.py
+++ b/mapper/mapper.py
@@ -208,11 +208,12 @@ class Mapper(threading.Thread, World):
 		return None
 
 	def emulation_command_exits(self, *args):
+		"""shows the exits in the room."""
 		exits = [key for key in DIRECTIONS if key in self.emulationRoom.exits.keys()]
 		self.output("Exits: {}.".format(", ".join(exits)))
 
 	def emulation_command_go(self, label, isJump=True):
-		"""mimic the /go command that the ainur use"""
+		"""mimic the /go command that the ainur use."""
 		room, error = self.getRoomFromLabel(label)
 		if error:
 			self.output(error)
@@ -226,7 +227,7 @@ class Mapper(threading.Thread, World):
 			self.lastEmulatedJump = room
 
 	def emulation_command_help(self, *args):
-		"""Shows documentation for mapper's emulation commands"""
+		"""Shows documentation for mapper's emulation commands."""
 		helpTexts = [(funcName, getattr(self, "emulation_command_"+funcName).__doc__)
 			for funcName in self.emulationCommands]
 		documentedFuncs = [text for text in helpTexts if text[1]]
@@ -234,23 +235,28 @@ class Mapper(threading.Thread, World):
 		self.output("""
 			The following commands allow you to emulate exploring the map without needing to move in game:
 			{}
-
-			The following commands have no documentation yet.
-			{}
 			""".format(
 				"\n".join(["    {}: {}".format(*helpText) for helpText in documentedFuncs]),
-				", ".join([helpText[0] for helpText in undocumentedFuncs]),
 			)
 		)
+		if undocumentedFuncs:
+			self.output("""
+				The following commands have no documentation yet.
+				{}
+				""".format(
+					", ".join([helpText[0] for helpText in undocumentedFuncs]),
+				)
+			)
 
 	def emulation_command_look(self, *args):
+		"""looks at the room."""
 		self.output(self.emulationRoom.name)
 		self.output(self.emulationRoom.dynamicDesc)
 		if self.emulationRoom.note:
 			self.output("Note: {0}".format(self.emulationRoom.note))
 
 	def emulation_command_return(self, *args):
-		"""returns to the last room jumped to with the go command"""
+		"""returns to the last room jumped to with the go command."""
 		if self.lastEmulatedJump:
 			self.emulation_command_go(self.lastEmulatedJump)
 		else:

--- a/mapper/mapper.py
+++ b/mapper/mapper.py
@@ -207,6 +207,10 @@ class Mapper(threading.Thread, World):
 		self._server.sendall(msg.encode("utf-8").replace(IAC, IAC + IAC) + b"\r\n")
 		return None
 
+	def emulation_command_examine(self, *args):
+		"""shows the room's description."""
+		self.output(self.emulationRoom.desc)
+
 	def emulation_command_exits(self, *args):
 		"""shows the exits in the room."""
 		exits = [key for key in DIRECTIONS if key in self.emulationRoom.exits.keys()]

--- a/mapper/mapper.py
+++ b/mapper/mapper.py
@@ -205,6 +205,10 @@ class Mapper(threading.Thread, World):
 		self._server.sendall(msg.encode("utf-8").replace(IAC, IAC + IAC) + b"\r\n")
 		return None
 
+	def emulation_command_ex(self, *args):
+		exits = [key for key in DIRECTIONS if key in self.emulationRoom.exits.keys()]
+		self.output("Exits: {}.".format(", ".join(exits)))
+
 	def emulation_command_l(self, *args):
 		self.output(self.emulationRoom.name)
 		self.output(self.emulationRoom.dynamicDesc)

--- a/mapper/mapper.py
+++ b/mapper/mapper.py
@@ -216,16 +216,15 @@ class Mapper(threading.Thread, World):
 			self.output("Note: {0}".format(self.emulationRoom.note))
 
 	def user_command_emu(self, *args):
-		command = args[0].split(" ")[0]
-		if command in self.emulationCommands:
-			getattr(self, "emulation_command_"+command)()
-		elif command:
+		inputText = args[0].split(" ")
+		userCommand = inputText[0].lower()
+		userArgs = " ".join(inputText[1:])
+		if userCommand in self.emulationCommands:
+			getattr(self, "emulation_command_"+userCommand)(userArgs)
+		elif userCommand:
 			self.output("Invalid emulation command. Options are: "+", ".join(self.emulationCommands))
 		else:
 			self.output("What command do you want to emulate?")
-
-	def emulation_command_test(self, *args):
-		self.output("emulating test")
 
 	def user_command_gettimer(self, *args):
 		self.clientSend("TIMER:{:d}:TIMER".format(int(default_timer() - self.initTimer)))

--- a/mapper/mapper.py
+++ b/mapper/mapper.py
@@ -403,9 +403,11 @@ class Mapper(threading.Thread, World):
 		self.clientSend("\n".join(self.rinfo(*args)))
 
 	def user_command_vnum(self, *args):
+		"""states the vnum of the current room"""
 		self.clientSend("Vnum: {}.".format(self.currentRoom.vnum))
 
 	def user_command_tvnum(self, *args):
+		"""tells a given char the vnum of your room"""
 		if not args or not args[0] or not args[0].strip():
 			self.clientSend("Tell VNum to who?")
 		else:
@@ -497,6 +499,25 @@ class Mapper(threading.Thread, World):
 			self.serverSend("look")
 		else:
 			self.sync(vnum=args[0].strip())
+
+	def user_command_maphelp(self, *args):
+		"""Shows documentation for mapper commands"""
+		helpTexts = [(funcName, getattr(self, "user_command_"+funcName).__doc__)
+			for funcName in self.userCommands]
+		documentedFuncs = [text for text in helpTexts if text[1]]
+		undocumentedFuncs = [text for text in helpTexts if not text[1]]
+		self.output("""
+			Mapper Commands
+			The following commands are used for viewing and editing map data:
+			{}
+
+			Undocumented Commands:
+			{}
+			""".format(
+				"\n".join(["{}: {}".format(*helpText) for helpText in documentedFuncs]),
+				", ".join([helpText[0] for helpText in undocumentedFuncs]),
+			)
+		)
 
 	def walkNextDirection(self):
 		if not self.autoWalkDirections:

--- a/mapper/mapper.py
+++ b/mapper/mapper.py
@@ -204,6 +204,12 @@ class Mapper(threading.Thread, World):
 		self._server.sendall(msg.encode("utf-8").replace(IAC, IAC + IAC) + b"\r\n")
 		return None
 
+	def emulation_command_l(self, *args):
+		self.output(self.emulationRoom.name)
+		self.output(self.emulationRoom.dynamicDesc)
+		if self.emulationRoom.note:
+			self.output("Note: {0}".format(self.emulationRoom.note))
+
 	def user_command_emu(self, *args):
 		command = args[0].split(" ")[0]
 		if command in self.emulationCommands:
@@ -215,9 +221,6 @@ class Mapper(threading.Thread, World):
 
 	def emulation_command_test(self, *args):
 		self.output("emulating test")
-
-	def emulation_command_l(self, *args):
-		self.output("emulating look")
 
 	def user_command_gettimer(self, *args):
 		self.clientSend("TIMER:{:d}:TIMER".format(int(default_timer() - self.initTimer)))

--- a/mapper/mapper.py
+++ b/mapper/mapper.py
@@ -155,6 +155,14 @@ class Mapper(threading.Thread, World):
 			if func and func.startswith("user_command_") and callable(self.__getattribute__(func))]
 		self.emulationCommands = [func[len("emulation_command_"):] for func in dir(self)
 			if func and func.startswith("emulation_command_") and callable(self.__getattribute__(func))]
+		priorityCommands = [  # commands that should have priority when matching user input to an emulation command
+			"exits",
+		]
+		self.emulationCommands.sort(key=lambda command:
+			command in priorityCommands and  # if the command has a specified priority, then
+				chr(priorityCommands.index(command))  # sort by its index in the list of priority commands
+				or chr(len(priorityCommands))+command  # else sort alphabetically
+		)
 		self.isEmulatingBriefMode = True
 		self.lastPathFindQuery = ""
 		self.lastPrompt = ""

--- a/mapper/mapper.py
+++ b/mapper/mapper.py
@@ -155,6 +155,7 @@ class Mapper(threading.Thread, World):
 			if func and func.startswith("user_command_") and callable(self.__getattribute__(func))]
 		self.emulationCommands = [func[len("emulation_command_"):] for func in dir(self)
 			if func and func.startswith("emulation_command_") and callable(self.__getattribute__(func))]
+		self.isEmulatingBriefMode = True
 		self.lastPathFindQuery = ""
 		self.lastPrompt = ""
 		self.clock = Clock()
@@ -207,6 +208,11 @@ class Mapper(threading.Thread, World):
 		self._server.sendall(msg.encode("utf-8").replace(IAC, IAC + IAC) + b"\r\n")
 		return None
 
+	def emulation_command_brief(self, *args):
+		"""toggles brief mode."""
+		self.isEmulatingBriefMode = False if self.isEmulatingBriefMode else True 
+		self.output("Brief mode {}".format("on" if self.isEmulatingBriefMode else "off"))
+
 	def emulation_command_examine(self, *args):
 		"""shows the room's description."""
 		self.output(self.emulationRoom.desc)
@@ -255,6 +261,8 @@ class Mapper(threading.Thread, World):
 	def emulation_command_look(self, *args):
 		"""looks at the room."""
 		self.output(self.emulationRoom.name)
+		if not self.isEmulatingBriefMode:
+			self.output(self.emulationRoom.desc)
 		self.output(self.emulationRoom.dynamicDesc)
 		if self.emulationRoom.note:
 			self.output("Note: {0}".format(self.emulationRoom.note))

--- a/mapper/mapper.py
+++ b/mapper/mapper.py
@@ -225,6 +225,19 @@ class Mapper(threading.Thread, World):
 		if self.emulationRoom.note:
 			self.output("Note: {0}".format(self.emulationRoom.note))
 
+	def emulate_leave(self, direction):
+		"""emulates leaving the room into a neighbouring room"""
+		if direction not in self.emulationRoom.exits:
+			self.output("Alas, you cannot go that way...")
+			return
+		room = self.emulationRoom.exits[direction].to
+		if "death" == room:
+			self.output("deathtrap!")
+		elif "undefined" == room:
+			self.output("undefined")
+		else:
+			self.emulation_command_go(room)
+
 	def user_command_emu(self, *args):
 		inputText = args[0].split(" ")
 		userCommand = inputText[0].lower()
@@ -232,7 +245,12 @@ class Mapper(threading.Thread, World):
 		if userCommand in self.emulationCommands:
 			getattr(self, "emulation_command_"+userCommand)(userArgs)
 		elif userCommand:
-			self.output("Invalid emulation command. Options are: "+", ".join(self.emulationCommands))
+			direction = [direction for direction in DIRECTIONS if direction.startswith(userCommand)]
+			if direction:
+				self.emulate_leave(direction[0])
+			else:
+				self.output("Invalid emulation command. Options are: {options}, or any direction."\
+					.format(options=", ".join(self.emulationCommands)))
 		else:
 			self.output("What command do you want to emulate?")
 

--- a/mapper/mapper.py
+++ b/mapper/mapper.py
@@ -209,6 +209,16 @@ class Mapper(threading.Thread, World):
 		exits = [key for key in DIRECTIONS if key in self.emulationRoom.exits.keys()]
 		self.output("Exits: {}.".format(", ".join(exits)))
 
+	def emulation_command_go(self, label):
+		"""mimic the /go command that the ainur use"""
+		room, error = self.getRoomFromLabel(label)
+		if error:
+			self.output(error)
+			return
+		self.emulationRoom = room
+		self.emulation_command_l()
+		self.emulation_command_ex()
+
 	def emulation_command_l(self, *args):
 		self.output(self.emulationRoom.name)
 		self.output(self.emulationRoom.dynamicDesc)

--- a/mapper/mapper.py
+++ b/mapper/mapper.py
@@ -132,7 +132,7 @@ MUD_DATA = 1
 
 
 class Mapper(threading.Thread, World):
-	def __init__(self, client, server, outputFormat, interface, promptTerminator, gagPrompts, findFormat, emulation=False):
+	def __init__(self, client, server, outputFormat, interface, promptTerminator, gagPrompts, findFormat, isEmulatingOffline=False):
 		threading.Thread.__init__(self)
 		self.name = "Mapper"
 		# Initialize the timer.
@@ -143,7 +143,7 @@ class Mapper(threading.Thread, World):
 		self._promptTerminator = promptTerminator
 		self.gagPrompts = gagPrompts
 		self.findFormat = findFormat
-		self.emulation = emulation
+		self.isEmulatingOffline = isEmulatingOffline
 		self.queue = Queue()
 		self.autoMapping = False
 		self.autoUpdating = False
@@ -220,7 +220,7 @@ class Mapper(threading.Thread, World):
 		self.emulationRoom = room
 		self.emulation_command_l()
 		self.emulation_command_ex()
-		if self.emulation:
+		if self.isEmulatingOffline:
 			self.currentRoom = self.emulationRoom
 		if isJump:
 			self.lastEmulatedJump = room
@@ -241,7 +241,7 @@ class Mapper(threading.Thread, World):
 	def emulation_command_sync(self, *args):
 		"""When emulating while connected to the mud, syncs the emulated location with the in-game location.
 		When running in offline mode, is equivalent to the return command."""
-		if self.emulation:
+		if self.isEmulatingOffline:
 			self.emulation_command_return()
 		else:
 			self.emulation_command_go(self.currentRoom)
@@ -265,7 +265,7 @@ class Mapper(threading.Thread, World):
 		userArgs = " ".join(inputText[1:])
 		if userCommand in self.emulationCommands:
 			getattr(self, "emulation_command_"+userCommand)(userArgs)
-		elif self.emulation and userCommand in self.userCommands:
+		elif self.isEmulatingOffline and userCommand in self.userCommands:
 			getattr(self, "user_command_"+userCommand)(userArgs)
 		elif userCommand:
 			direction = [direction for direction in DIRECTIONS if direction.startswith(userCommand)]
@@ -704,7 +704,7 @@ class Mapper(threading.Thread, World):
 				break
 			elif dataType == USER_DATA:
 				# The data was a valid mapper command, sent from the user's mud client.
-				if self.emulation:
+				if self.isEmulatingOffline:
 					self.user_command_emu(decodeBytes(data).strip())
 				else:
 					userCommand = data.strip().split()[0]

--- a/mapper/mapper.py
+++ b/mapper/mapper.py
@@ -234,6 +234,14 @@ class Mapper(threading.Thread, World):
 		else:
 			self.output("Cannot return anywhere until the go command has been used at least once.")
 
+	def emulation_command_sync(self, *args):
+		"""When emulating while connected to the mud, syncs the emulated location with the in-game location.
+		When running in offline mode, is equivalent to the return command."""
+		if self.emulation:
+			self.emulation_command_return()
+		else:
+			self.emulation_command_go(self.currentRoom)
+
 	def emulate_leave(self, direction):
 		"""emulates leaving the room into a neighbouring room"""
 		if direction not in self.emulationRoom.exits:

--- a/mapper/mapper.py
+++ b/mapper/mapper.py
@@ -151,6 +151,8 @@ class Mapper(threading.Thread, World):
 		self.autoLinking = True
 		self.autoWalk = False
 		self.autoWalkDirections = []
+		self.userCommands = [func[len("user_command_"):] for func in dir(self)
+			if func and func.startswith("user_command_") and callable(self.__getattribute__(func))]
 		self.emulationCommands = [func[len("emulation_command_"):] for func in dir(self)
 			if func and func.startswith("emulation_command_") and callable(self.__getattribute__(func))]
 		self.lastPathFindQuery = ""
@@ -218,6 +220,8 @@ class Mapper(threading.Thread, World):
 		self.emulationRoom = room
 		self.emulation_command_l()
 		self.emulation_command_ex()
+		if self.emulation:
+			self.currentRoom = self.emulationRoom
 		if isJump:
 			self.lastEmulatedJump = room
 
@@ -261,6 +265,8 @@ class Mapper(threading.Thread, World):
 		userArgs = " ".join(inputText[1:])
 		if userCommand in self.emulationCommands:
 			getattr(self, "emulation_command_"+userCommand)(userArgs)
+		elif self.emulation and userCommand in self.userCommands:
+			getattr(self, "user_command_"+userCommand)(userArgs)
 		elif userCommand:
 			direction = [direction for direction in DIRECTIONS if direction.startswith(userCommand)]
 			if direction:

--- a/mapper/mapper.py
+++ b/mapper/mapper.py
@@ -150,6 +150,8 @@ class Mapper(threading.Thread, World):
 		self.autoLinking = True
 		self.autoWalk = False
 		self.autoWalkDirections = []
+		self.emulationCommands = [func[len("emulation_command_"):] for func in dir(self)
+			if func and func.startswith("emulation_command_") and callable(self.__getattribute__(func))]
 		self.lastPathFindQuery = ""
 		self.lastPrompt = ""
 		self.clock = Clock()
@@ -201,6 +203,15 @@ class Mapper(threading.Thread, World):
 	def serverSend(self, msg):
 		self._server.sendall(msg.encode("utf-8").replace(IAC, IAC + IAC) + b"\r\n")
 		return None
+
+	def user_command_emu(self, *args):
+		self.output("the available emulation commands are: "+", ".join(self.emulationCommands))
+
+	def emulation_command_test(self, *args):
+		pass
+
+	def emulation_command_l(self, *args):
+		pass
 
 	def user_command_gettimer(self, *args):
 		self.clientSend("TIMER:{:d}:TIMER".format(int(default_timer() - self.initTimer)))

--- a/mapper/mapper.py
+++ b/mapper/mapper.py
@@ -132,7 +132,7 @@ MUD_DATA = 1
 
 
 class Mapper(threading.Thread, World):
-	def __init__(self, client, server, outputFormat, interface, promptTerminator, gagPrompts, findFormat):
+	def __init__(self, client, server, outputFormat, interface, promptTerminator, gagPrompts, findFormat, emulation=False):
 		threading.Thread.__init__(self)
 		self.name = "Mapper"
 		# Initialize the timer.
@@ -143,6 +143,7 @@ class Mapper(threading.Thread, World):
 		self._promptTerminator = promptTerminator
 		self.gagPrompts = gagPrompts
 		self.findFormat = findFormat
+		self.emulation = emulation
 		self.queue = Queue()
 		self.autoMapping = False
 		self.autoUpdating = False
@@ -649,9 +650,12 @@ class Mapper(threading.Thread, World):
 				break
 			elif dataType == USER_DATA:
 				# The data was a valid mapper command, sent from the user's mud client.
-				userCommand = data.strip().split()[0]
-				args = data[len(userCommand):].strip()
-				getattr(self, "user_command_{}".format(decodeBytes(userCommand)))(decodeBytes(args))
+				if self.emulation:
+					self.user_command_emu(decodeBytes(data).strip())
+				else:
+					userCommand = data.strip().split()[0]
+					args = data[len(userCommand):].strip()
+					getattr(self, "user_command_{}".format(decodeBytes(userCommand)))(decodeBytes(args))
 				continue
 			# The data was from the mud server.
 			event, data = data

--- a/mapper/mapper.py
+++ b/mapper/mapper.py
@@ -225,6 +225,24 @@ class Mapper(threading.Thread, World):
 		if isJump:
 			self.lastEmulatedJump = room
 
+	def emulation_command_help(self, *args):
+		"""Shows documentation for mapper's emulation commands"""
+		helpTexts = [(funcName, getattr(self, "emulation_command_"+funcName).__doc__)
+			for funcName in self.emulationCommands]
+		documentedFuncs = [text for text in helpTexts if text[1]]
+		undocumentedFuncs = [text for text in helpTexts if not text[1]]
+		self.output("""
+			The following commands allow you to emulate exploring the map without needing to move in game:
+			{}
+
+			The following commands have no documentation yet.
+			{}
+			""".format(
+				"\n".join(["    {}: {}".format(*helpText) for helpText in documentedFuncs]),
+				", ".join([helpText[0] for helpText in undocumentedFuncs]),
+			)
+		)
+
 	def emulation_command_l(self, *args):
 		self.output(self.emulationRoom.name)
 		self.output(self.emulationRoom.dynamicDesc)
@@ -272,8 +290,7 @@ class Mapper(threading.Thread, World):
 			if direction:
 				self.emulate_leave(direction[0])
 			else:
-				self.output("Invalid emulation command. Options are: {options}, or any direction."\
-					.format(options=", ".join(self.emulationCommands)))
+				self.output("Invalid command. Type 'help' for more help.")
 		else:
 			self.output("What command do you want to emulate?")
 

--- a/mapper/mapper.py
+++ b/mapper/mapper.py
@@ -205,13 +205,19 @@ class Mapper(threading.Thread, World):
 		return None
 
 	def user_command_emu(self, *args):
-		self.output("the available emulation commands are: "+", ".join(self.emulationCommands))
+		command = args[0].split(" ")[0]
+		if command in self.emulationCommands:
+			getattr(self, "emulation_command_"+command)()
+		elif command:
+			self.output("Invalid emulation command. Options are: "+", ".join(self.emulationCommands))
+		else:
+			self.output("What command do you want to emulate?")
 
 	def emulation_command_test(self, *args):
-		pass
+		self.output("emulating test")
 
 	def emulation_command_l(self, *args):
-		pass
+		self.output("emulating look")
 
 	def user_command_gettimer(self, *args):
 		self.clientSend("TIMER:{:d}:TIMER".format(int(default_timer() - self.initTimer)))

--- a/mapper/mapper.py
+++ b/mapper/mapper.py
@@ -283,8 +283,13 @@ class Mapper(threading.Thread, World):
 		userArgs = " ".join(inputText[1:])
 		if userCommand in self.emulationCommands:
 			getattr(self, "emulation_command_"+userCommand)(userArgs)
-		elif self.isEmulatingOffline and userCommand in self.userCommands:
+		elif userCommand in self.userCommands:
+			# call the user command
+			# first set current room to the emulation room so the user command acts on the emulation room
+			oldRoom = self.currentRoom
+			self.currentRoom = self.emulationRoom
 			getattr(self, "user_command_"+userCommand)(userArgs)
+			self.currentRoom = oldRoom
 		elif userCommand:
 			direction = [direction for direction in DIRECTIONS if direction.startswith(userCommand)]
 			if direction:

--- a/mapper/mapper.py
+++ b/mapper/mapper.py
@@ -209,7 +209,7 @@ class Mapper(threading.Thread, World):
 		exits = [key for key in DIRECTIONS if key in self.emulationRoom.exits.keys()]
 		self.output("Exits: {}.".format(", ".join(exits)))
 
-	def emulation_command_go(self, label):
+	def emulation_command_go(self, label, isJump=True):
 		"""mimic the /go command that the ainur use"""
 		room, error = self.getRoomFromLabel(label)
 		if error:
@@ -218,12 +218,21 @@ class Mapper(threading.Thread, World):
 		self.emulationRoom = room
 		self.emulation_command_l()
 		self.emulation_command_ex()
+		if isJump:
+			self.lastEmulatedJump = room
 
 	def emulation_command_l(self, *args):
 		self.output(self.emulationRoom.name)
 		self.output(self.emulationRoom.dynamicDesc)
 		if self.emulationRoom.note:
 			self.output("Note: {0}".format(self.emulationRoom.note))
+
+	def emulation_command_return(self, *args):
+		"""returns to the last room jumped to with the go command"""
+		if self.lastEmulatedJump:
+			self.emulation_command_go(self.lastEmulatedJump)
+		else:
+			self.output("Cannot return anywhere until the go command has been used at least once.")
 
 	def emulate_leave(self, direction):
 		"""emulates leaving the room into a neighbouring room"""
@@ -236,7 +245,7 @@ class Mapper(threading.Thread, World):
 		elif "undefined" == room:
 			self.output("undefined")
 		else:
-			self.emulation_command_go(room)
+			self.emulation_command_go(room, isJump=False)
 
 	def user_command_emu(self, *args):
 		inputText = args[0].split(" ")

--- a/mapper/world.py
+++ b/mapper/world.py
@@ -184,6 +184,7 @@ class World(object):
 			del roomDict
 		self.currentRoom = self.rooms["0"]
 		self.emulationRoom = self.rooms["0"]
+		self.lastEmulatedJump = None
 		if not gc.isenabled():
 			gc.enable()
 			gc.collect()

--- a/mapper/world.py
+++ b/mapper/world.py
@@ -938,6 +938,16 @@ class World(object):
 		return results
 
 	def getRoomFromLabel(self, label):
+		"""Takes a single argument, and returns a tuple of length 2.
+		If successful, the first element returned is a room object, and the second element is none.
+		Otherwise, the first element returned is None, and the second element is a human-readable error message.
+		If the given argument is a room object, it is returned as is.
+		If the given argument is a room vnum corresponding to an extant room, the corresponding room is returned.
+		If the given argument is the label of a room, that room is returned.
+		Otherwise, None is returned with a helpful error message for the user.
+		"""
+		if isinstance(label, roomdata.objects.Room):
+			return label, None
 		label = label.strip().lower()
 		if not label:
 			return None, "No label or room vnum specified."

--- a/mapper/world.py
+++ b/mapper/world.py
@@ -183,6 +183,7 @@ class World(object):
 			roomDict.clear()
 			del roomDict
 		self.currentRoom = self.rooms["0"]
+		self.emulationRoom = self.rooms["0"]
 		if not gc.isenabled():
 			gc.enable()
 			gc.collect()

--- a/start.py
+++ b/start.py
@@ -101,7 +101,7 @@ if __name__ == "__main__":
 		mapper.main.main(
 			outputFormat=args.format,
 			interface=args.interface,
-			emulation=args.emulation,
+			isEmulatingOffline=args.emulation,
 			promptTerminator=b"\r\n" if args.prompt_terminator_lf else None,
 			gagPrompts=args.gag_prompts,
 			findFormat=args.find_format,

--- a/start.py
+++ b/start.py
@@ -11,7 +11,6 @@ import sys
 import traceback
 
 import mapper.main
-import mapper.emulation
 
 try:
 	from mpm_version import version
@@ -97,22 +96,21 @@ if __name__ == "__main__":
 		default="{vnum}, {name}, {attribute}"
 	)
 	args = parser.parse_args()
+
 	try:
-		if args.emulation:
-			mapper.emulation.main(interface=args.interface, findFormat=args.find_format)
-		else:
-			mapper.main.main(
-				outputFormat=args.format,
-				interface=args.interface,
-				promptTerminator=b"\r\n" if args.prompt_terminator_lf else None,
-				gagPrompts=args.gag_prompts,
-				findFormat=args.find_format,
-				localHost=args.local_host,
-				localPort=args.local_port,
-				remoteHost=args.remote_host,
-				remotePort=args.remote_port,
-				noSsl=args.no_ssl
-			)
+		mapper.main.main(
+			outputFormat=args.format,
+			interface=args.interface,
+			emulation=args.emulation,
+			promptTerminator=b"\r\n" if args.prompt_terminator_lf else None,
+			gagPrompts=args.gag_prompts,
+			findFormat=args.find_format,
+			localHost=args.local_host,
+			localPort=args.local_port,
+			remoteHost=args.remote_host,
+			remotePort=args.remote_port,
+			noSsl=args.no_ssl
+		)
 	except Exception:
 		traceback.print_exception(*sys.exc_info())
 		logging.exception("OOPS!")


### PR DESCRIPTION
The emulation mode interfaces with the user's client instead of running in a command prompt window. By default, the mapper connects to the mud, and emulation is done by prefixing commands with "emu". If the -e flag is passed to the mapper, it does not connect to the mud, but still interfaces with the user's client, mocking the experience of exploring the map through the user's client. For more help, type "emu help" when playing normally, or just type "help" when emulating offline.

the code for emulation is now in the mapper class, and is able to reuse existing mapper commands such as rinfo and rlink. emulation.py is now obsolete, and is only kept for code samples, as only the basic exploration commands have been implemented in the mapper class.