### PR TITLE
test server thread

### DIFF
--- a/test/mapper/test_main.py
+++ b/test/mapper/test_main.py
@@ -1,16 +1,16 @@
 import unittest
 from unittest.mock import call, Mock
+
+from mapper.main import *
 from telnetlib import CHARSET, ECHO, IAC, NAWS, RCP, SB, TTYPE, WILL
 from queue import Empty, Queue
 
-from mapper.main import *
-
-initialOutput = IAC+DO+TTYPE+IAC+DO+NAWS
-welcomeMessage = b"\r\n                              ***  MUME VIII  ***\r\n\r\n"
+INITIAL_OUTPUT = IAC+DO+TTYPE+IAC+DO+NAWS
+WELCOME_MESSAGE = b"\r\n                              ***  MUME VIII  ***\r\n\r\n"
 
 
 class TestServerThread(unittest.TestCase):
-	def testServerThreadInitialises(self):
+	def testServerThread(self):
 		initialConfiguration = [
 			b"~$#EI\n",
 			b"~$#EX2\n3G\n",
@@ -18,28 +18,28 @@ class TestServerThread(unittest.TestCase):
 			IAC+WILL+CHARSET,
 		]
 
-		serverSocket = Mock(spec=socket.socket)
+		mumeSocket = Mock(spec=socket.socket)
 		outputFromMume = Queue()
 		inputToMume = Queue()
-		serverSocket.recv.side_effect = lambda arg: outputFromMume.get()
-		serverSocket.sendall.side_effect = lambda data: inputToMume.put(data)
+		mumeSocket.recv.side_effect = lambda arg: outputFromMume.get()
+		mumeSocket.sendall.side_effect = lambda data: inputToMume.put(data)
 		clientSocket = Mock(spec=socket.socket)
 		outputToUser = Queue()
 		clientSocket.sendall.side_effect = lambda data: outputToUser.put(data)
 
 		serverThread = Server(
 			client=clientSocket,
-			server=serverSocket,
+			server=mumeSocket,
 			mapper=Mock(),
 			outputFormat=None,
 			interface="text",
 			promptTerminator=None
 		)
-		serverThread.daemon = True
+		serverThread.daemon = True  # otherwise if this does not terminate, it prevents unittest from terminating
 		serverThread.start()
 
-		# test that the initial configuration parameters are outputted when the server first replies
-		outputFromMume.put(initialOutput)
+		# test when the server sends its initial negociations, the server thread outputs its initial configuration
+		outputFromMume.put(INITIAL_OUTPUT)
 		try:
 			while initialConfiguration:
 				data = inputToMume.get(timeout=1)
@@ -48,43 +48,41 @@ class TestServerThread(unittest.TestCase):
 		except Empty:
 			raise AssertionError("The server thread did not output the expected number of configuration parameters.\
 				The yet-to-be-seen configurations are: "+"; ".join(initialConfiguration))
+
+		# test nothing extr has been sent yet
 		if not inputToMume.empty():
 			remainingOutput = inputToMume.get()
 			raise AssertionError("The server thread spat out at least one unexpected initial configuration: "+str(remainingOutput))
 
-		# test initial telnet negociation was passed to the client
+		# test initial telnet negociations were passed to the client
 		try:
 			data = outputToUser.get(timeout=1)
-			self.assertEqual(data, initialOutput)
+			self.assertEqual(data, INITIAL_OUTPUT)
 		except Empty:
 			raise AssertionError("initial telnet negociations were not passed to the client")
 			
 		# test regular text is passed through to the client
 		try:
-			outputFromMume.put(welcomeMessage)
-			clientWelcomeMessage = outputToUser.get(timeout=1)
-			self.assertEqual(welcomeMessage, clientWelcomeMessage)
+			outputFromMume.put(WELCOME_MESSAGE)
+			data = outputToUser.get(timeout=1)
+			self.assertEqual(WELCOME_MESSAGE, data)
 		except Empty:
 			raise AssertionError("The welcome message was not passed through to the client within 1 second.")
 		
-		self.assertTrue(outputFromMume.empty())
-		self.assertTrue(inputToMume.empty())
-		self.assertTrue(outputToUser.empty())
-
-		# test that further telnet negociations are passed to the client with the exception of charset negociations
+		# test further telnet negociations are passed to the client with the exception of charset negociations
 		try:
 			charsetNegociation = IAC+DO+CHARSET+IAC+SB+TTYPE+ECHO+IAC+SE
 			charsetSubnegociation = IAC+SB+CHARSET+RCP+b"US-ASCII"+IAC+SE
 			outputFromMume.put(charsetNegociation)
 			data = outputToUser.get(timeout=1)
-			self.assertEqual(data, charsetNegociation[3:])
+			self.assertEqual(data, charsetNegociation[3:])  # slicing off the charset negociation
 			outputFromMume.put(charsetSubnegociation)
 			data = outputToUser.get(timeout=1)
 			self.assertEqual(data, b"")
 		except Empty:
 			raise AssertionError("Further telnet negociations were not passed to the client")
 
-		# test further text is passed to the user
+		# when mume outputs further text, test it is passed to the user
 		try:
 			usernamePrompt = b"By what name do you wish to be known? "
 			outputFromMume.put(usernamePrompt)
@@ -93,7 +91,7 @@ class TestServerThread(unittest.TestCase):
 		except Empty:
 			raise AssertionError("Further text was not passed to the user")
 
-		# close server thread
+		# when mume outputs an empty string, test server thread closes within a second
 		outputFromMume.put(b"")
 		serverThread.join(1)
 		self.assertFalse(serverThread.is_alive())

--- a/test/mapper/test_main.py
+++ b/test/mapper/test_main.py
@@ -9,19 +9,23 @@ from mapper.main import *
 
 class TestServerThread(unittest.TestCase):
 	def testServerThreadInitialises(self):
+		initialConfiguration = [
+			b"~$#EI\n",
+			b"~$#EX2\n3G\n",
+			b"~$#EP2\nG\n",
+			IAC+WILL+b"*",
+		]
 
-		
-		
 		serverSocket = Mock(spec=socket.socket)
-		serverSocketOutput = Queue()
-		serverSocketInput = Queue()
-		serverSocket.recv.side_effect = lambda arg: serverSocketOutput.get()
-		serverSocket.sendall.side_effect = lambda data: serverSocketInput.put(data)
+		outputFromMume = Queue()
+		inputToMume = Queue()
+		serverSocket.recv.side_effect = lambda arg: outputFromMume.get()
+		serverSocket.sendall.side_effect = lambda data: inputToMume.put(data)
 		clientSocket = Mock(spec=socket.socket)
-		clientSocketOutput = Queue()
-		clientSocketInput = Queue()
-		clientSocket.recv.side_effect = lambda arg: clientSocketOutput.get()
-		clientSocket.sendall.side_effect = lambda data: clientSocketOutput.put(data)
+		inputFromUser = Queue()
+		outputToUser = Queue()
+		clientSocket.recv.side_effect = lambda arg: inputFromUser.get()
+		clientSocket.sendall.side_effect = lambda data: outputToUser.put(data)
 
 		serverThread = Server(
 			client=clientSocket,
@@ -31,35 +35,22 @@ class TestServerThread(unittest.TestCase):
 			interface="text",
 			promptTerminator=None
 		)
-		serverThread.daemon = True
 		serverThread.start()
-		initialConfiguration = [
-			b"~$#EI\n",
-			b"~$#EX2\n3G\n",
-			b"~$#EP2\nG\n",
-			IAC+WILL+b"*",
-		]
 
 		# test that the initial configuration parameters are outputted when the server first replies
-		serverSocketOutput.put(IAC+DO+TTYPE+IAC+DO+NAWS,)
+		outputFromMume.put(IAC+DO+TTYPE+IAC+DO+NAWS,)
 		try:
 			while initialConfiguration:
-				output = serverSocketInput.get(timeout=1)
-				self.assertIn(output, initialConfiguration, "Unknown initial configuration: "+str(output))
-				initialConfiguration.remove(output)
+				data = inputToMume.get(timeout=1)
+				self.assertIn(data, initialConfiguration, "Unknown initial configuration: "+str(data))
+				initialConfiguration.remove(data)
 		except Empty:
 			raise AssertionError("The server thread did not output the expected number of configuration parameters.\
 				The yet-to-be-seen configurations are: "+"; ".join(initialConfiguration))
-		if not serverSocketInput.empty():
-			remainingOutput = serverSocketInput.get()
-			raise AssertionError("The server thread spat out at least once unexpected initial configuration: "+str(remainingOutput))
+		if not inputToMume.empty():
+			remainingOutput = inputToMume.get()
+			raise AssertionError("The server thread spat out at least one unexpected initial configuration: "+str(remainingOutput))
 		
-		print("size of array is "+str(len(initialConfiguration)))
-		self.assertFalse(initialConfiguration, "have not seen all the expected initial configurations")
-		
-
-		# put initial telnet bits out of server
-		# test that negociation stuff came back out server input
 		#  out comes start screen
 		#assert it comes out other end
 		#in goes username
@@ -71,8 +62,6 @@ class TestServerThread(unittest.TestCase):
 		 #input nothing to close it
 		 # assert thread is dead
 		
-			#call(IAC+SB+b"*"+ECHO+b";US-ASCII"+IAC+SE),
-		#]
 		serverThreadInput = [  # list binary input in chronological order
 			b"\r\n                              ***  MUME VIII  ***\r\n\r\n                              In progress at FIRE\r\n                     (Free Internet Roleplay Experiences)\r\n                      Hosted at HEIG-VD (www.heig-vd.ch)\r\n\r\n             Adapted from J.R.R. Tolkien's Middle-earth world and\r\n                   maintained by CryHavoc, Manwe, and Nada.\r\n\r\n              Original code DikuMUD I (help credits), created by:\r\n       S. Hammer, T. Madsen, K. Nyboe, M. Seifert, and H.H. Staerfeldt.\r\n\r\nIf you have never played MUME before, type NEW to create a new character,\r\nor ? for help. Otherwise, type your account or character name.\r\n\r\n\r\n",
 			b"By what name do you wish to be known? ",
@@ -81,6 +70,8 @@ class TestServerThread(unittest.TestCase):
 			b"",
 		]
 		serverThreadInput.reverse()  # reverse because the pop function takes from the end of the list
-		serverSocketOutput.put(b"")
+
+		# close server thread
+		outputFromMume.put(b"")
 		serverThread.join(1)
 		self.assertFalse(serverThread.is_alive())

--- a/test/mapper/test_main.py
+++ b/test/mapper/test_main.py
@@ -1,0 +1,43 @@
+import unittest
+from unittest.mock import call, Mock
+from telnetlib import ECHO, IAC, NAWS, SB, TTYPE, WILL
+
+from mapper.main import *
+
+
+class TestServerThread(unittest.TestCase):
+	def testServerThreadInitialises(self):
+		expectedOutput = [
+			call(b"~$#EI\n"),
+			call(b"~$#EX2\n3G\n"),
+			call(b"~$#EP2\nG\n"),
+			call(IAC+WILL+b"*"),
+			call(IAC+SB+b"*"+ECHO+b";US-ASCII"+IAC+SE),
+		]
+		serverThreadInput = [  # list binary input in chronological order
+			IAC+DO+TTYPE+IAC+DO+NAWS,
+			b"\r\n                              ***  MUME VIII  ***\r\n\r\n                              In progress at FIRE\r\n                     (Free Internet Roleplay Experiences)\r\n                      Hosted at HEIG-VD (www.heig-vd.ch)\r\n\r\n             Adapted from J.R.R. Tolkien's Middle-earth world and\r\n                   maintained by CryHavoc, Manwe, and Nada.\r\n\r\n              Original code DikuMUD I (help credits), created by:\r\n       S. Hammer, T. Madsen, K. Nyboe, M. Seifert, and H.H. Staerfeldt.\r\n\r\nIf you have never played MUME before, type NEW to create a new character,\r\nor ? for help. Otherwise, type your account or character name.\r\n\r\n\r\n",
+			b"By what name do you wish to be known? ",
+			IAC+DO+b"*"+IAC+SB+TTYPE+ECHO+IAC+SE,
+			b"IACSB*\x02US-ASCIIIACSE",
+			b"",
+		]
+		serverThreadInput.reverse()  # reverse because the pop function takes from the end of the list
+
+		serverSocket = Mock(spec=socket.socket)
+		serverSocket.recv.side_effect = lambda arg: serverThreadInput.pop()
+
+		serverThread = Server(
+			client=Mock(),
+			server=serverSocket,
+			mapper=Mock(),
+			outputFormat=None,
+			interface="text",
+			promptTerminator=None
+		)
+
+		serverThread.run()
+
+		for i in range(len(serverSocket.sendall.mock_calls)):
+			self.assertEqual( expectedOutput[i], serverSocket.sendall.mock_calls[i],
+				"verifying args of serverSocket.sendall in call number "+str(i))

--- a/test/mapper/test_main.py
+++ b/test/mapper/test_main.py
@@ -1,10 +1,12 @@
 import unittest
 from unittest.mock import call, Mock
 from telnetlib import ECHO, IAC, NAWS, SB, TTYPE, WILL
-from time import sleep
 from queue import Empty, Queue
 
 from mapper.main import *
+
+initialOutput = IAC+DO+TTYPE+IAC+DO+NAWS
+welcomeMessage = b"\r\n                              ***  MUME VIII  ***\r\n\r\n"
 
 
 class TestServerThread(unittest.TestCase):
@@ -22,9 +24,7 @@ class TestServerThread(unittest.TestCase):
 		serverSocket.recv.side_effect = lambda arg: outputFromMume.get()
 		serverSocket.sendall.side_effect = lambda data: inputToMume.put(data)
 		clientSocket = Mock(spec=socket.socket)
-		inputFromUser = Queue()
 		outputToUser = Queue()
-		clientSocket.recv.side_effect = lambda arg: inputFromUser.get()
 		clientSocket.sendall.side_effect = lambda data: outputToUser.put(data)
 
 		serverThread = Server(
@@ -35,10 +35,11 @@ class TestServerThread(unittest.TestCase):
 			interface="text",
 			promptTerminator=None
 		)
+		serverThread.daemon = True
 		serverThread.start()
 
 		# test that the initial configuration parameters are outputted when the server first replies
-		outputFromMume.put(IAC+DO+TTYPE+IAC+DO+NAWS,)
+		outputFromMume.put(initialOutput)
 		try:
 			while initialConfiguration:
 				data = inputToMume.get(timeout=1)
@@ -50,11 +51,22 @@ class TestServerThread(unittest.TestCase):
 		if not inputToMume.empty():
 			remainingOutput = inputToMume.get()
 			raise AssertionError("The server thread spat out at least one unexpected initial configuration: "+str(remainingOutput))
-		
-		#  out comes start screen
-		#assert it comes out other end
-		#in goes username
-		#assert comes out
+
+		# test initial telnet negociation was passed to the client
+		try:
+			data = outputToUser.get(timeout=1)
+			self.assertEqual(data, initialOutput)
+		except Empty:
+			raise AssertionError("initial telnet negociations were not passed to the client")
+			
+		# test regular text is passed through to the client
+		try:
+			outputFromMume.put(welcomeMessage)
+			clientWelcomeMessage = outputToUser.get(timeout=1)
+			self.assertEqual(welcomeMessage, clientWelcomeMessage)
+		except Empty:
+			raise AssertionError("The welcome message was not passed through to the client within 1 second.")
+
 		#in goes some more negociation
 		#assert it comes out
 		# put in password
@@ -63,8 +75,6 @@ class TestServerThread(unittest.TestCase):
 		 # assert thread is dead
 		
 		serverThreadInput = [  # list binary input in chronological order
-			b"\r\n                              ***  MUME VIII  ***\r\n\r\n                              In progress at FIRE\r\n                     (Free Internet Roleplay Experiences)\r\n                      Hosted at HEIG-VD (www.heig-vd.ch)\r\n\r\n             Adapted from J.R.R. Tolkien's Middle-earth world and\r\n                   maintained by CryHavoc, Manwe, and Nada.\r\n\r\n              Original code DikuMUD I (help credits), created by:\r\n       S. Hammer, T. Madsen, K. Nyboe, M. Seifert, and H.H. Staerfeldt.\r\n\r\nIf you have never played MUME before, type NEW to create a new character,\r\nor ? for help. Otherwise, type your account or character name.\r\n\r\n\r\n",
-			b"By what name do you wish to be known? ",
 			IAC+DO+b"*"+IAC+SB+TTYPE+ECHO+IAC+SE,
 			b"IACSB*\x02US-ASCIIIACSE",
 			b"",

--- a/test/mapper/test_main.py
+++ b/test/mapper/test_main.py
@@ -1,21 +1,64 @@
 import unittest
 from unittest.mock import call, Mock
 from telnetlib import ECHO, IAC, NAWS, SB, TTYPE, WILL
+from queue import Queue
 
 from mapper.main import *
 
 
 class TestServerThread(unittest.TestCase):
 	def testServerThreadInitialises(self):
-		expectedOutput = [
-			call(b"~$#EI\n"),
+
+		
+		
+		serverSocket = Mock(spec=socket.socket)
+		serverSocketOutput = Queue()
+		serverSocketInput = Queue()
+		serverSocket.recv.side_effect = lambda arg: serverSocketOutput.get()
+		serverSocket.sendall.side_effect = lambda data: serverSocketInput.put(data)
+		clientSocket = Mock(spec=socket.socket)
+		clientSocketOutput = Queue()
+		clientSocketInput = Queue()
+		clientSocket.recv.side_effect = lambda arg: clientSocketOutput.get()
+		clientSocket.sendall.side_effect = lambda data: clientSocketOutput.put(data)
+
+		serverThread = Server(
+			client=clientSocket,
+			server=serverSocket,
+			mapper=Mock(),
+			outputFormat=None,
+			interface="text",
+			promptTerminator=None
+		)
+		serverThread.start()
+
+		serverSocketOutput.put(IAC+DO+TTYPE+IAC+DO+NAWS,)
+		self.assertEqual(serverSocketInput.get(), b"~$#EI\n")
+		#self.assertEqual(initialConfiguration, serverSocket.sendall.mock_calls)
+		
+		initialConfiguration = [
+			call(),
 			call(b"~$#EX2\n3G\n"),
 			call(b"~$#EP2\nG\n"),
 			call(IAC+WILL+b"*"),
-			call(IAC+SB+b"*"+ECHO+b";US-ASCII"+IAC+SE),
 		]
+
+		# put initial telnet bits out of server
+		# test that negociation stuff came back out server input
+		#  out comes start screen
+		#assert it comes out other end
+		#in goes username
+		#assert comes out
+		#in goes some more negociation
+		#assert it comes out
+		# put in password
+		#assert it comes out
+		 #input nothing to close it
+		 # assert thread is dead
+		
+			#call(IAC+SB+b"*"+ECHO+b";US-ASCII"+IAC+SE),
+		#]
 		serverThreadInput = [  # list binary input in chronological order
-			IAC+DO+TTYPE+IAC+DO+NAWS,
 			b"\r\n                              ***  MUME VIII  ***\r\n\r\n                              In progress at FIRE\r\n                     (Free Internet Roleplay Experiences)\r\n                      Hosted at HEIG-VD (www.heig-vd.ch)\r\n\r\n             Adapted from J.R.R. Tolkien's Middle-earth world and\r\n                   maintained by CryHavoc, Manwe, and Nada.\r\n\r\n              Original code DikuMUD I (help credits), created by:\r\n       S. Hammer, T. Madsen, K. Nyboe, M. Seifert, and H.H. Staerfeldt.\r\n\r\nIf you have never played MUME before, type NEW to create a new character,\r\nor ? for help. Otherwise, type your account or character name.\r\n\r\n\r\n",
 			b"By what name do you wish to be known? ",
 			IAC+DO+b"*"+IAC+SB+TTYPE+ECHO+IAC+SE,
@@ -23,21 +66,6 @@ class TestServerThread(unittest.TestCase):
 			b"",
 		]
 		serverThreadInput.reverse()  # reverse because the pop function takes from the end of the list
-
-		serverSocket = Mock(spec=socket.socket)
-		serverSocket.recv.side_effect = lambda arg: serverThreadInput.pop()
-
-		serverThread = Server(
-			client=Mock(),
-			server=serverSocket,
-			mapper=Mock(),
-			outputFormat=None,
-			interface="text",
-			promptTerminator=None
-		)
-
-		serverThread.run()
-
-		for i in range(len(serverSocket.sendall.mock_calls)):
-			self.assertEqual( expectedOutput[i], serverSocket.sendall.mock_calls[i],
-				"verifying args of serverSocket.sendall in call number "+str(i))
+		serverSocketOutput.put(b"")
+		serverThread.join(1)
+		self.assertTrue(serverThread.is_alive())

--- a/tests/mapper/test_main.py
+++ b/tests/mapper/test_main.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import unittest
 from unittest.mock import call, Mock
 
@@ -60,7 +64,7 @@ class TestServerThread(unittest.TestCase):
 			self.assertEqual(data, INITIAL_OUTPUT)
 		except Empty:
 			raise AssertionError("initial telnet negociations were not passed to the client")
-			
+
 		# test regular text is passed through to the client
 		try:
 			outputFromMume.put(WELCOME_MESSAGE)
@@ -68,7 +72,7 @@ class TestServerThread(unittest.TestCase):
 			self.assertEqual(WELCOME_MESSAGE, data)
 		except Empty:
 			raise AssertionError("The welcome message was not passed through to the client within 1 second.")
-		
+
 		# test further telnet negociations are passed to the client with the exception of charset negociations
 		try:
 			charsetNegociation = IAC+DO+CHARSET+IAC+SB+TTYPE+ECHO+IAC+SE


### PR DESCRIPTION
add the directory structure to hold tests, which mimics the directory structure of the source code.

add a comprehensive test of the server thread

run $python -m unittest, and it will execute all test functions that start with the word "test", and are in a class that inherit from unittest.TestCase, and is in a file that starts with the word "test", in and is in a folder that has an __init__.py file and is a subdirectory of test.