### PR TITLE
Mud Events

### DIFF
--- a/mapper/cleanmap.py
+++ b/mapper/cleanmap.py
@@ -14,7 +14,13 @@ exitRegexp = re.compile(
 
 
 class ExitsCleaner(Handler):
+	event = "exits"
+
 	def handle(self, data):
+		"""Receives the output from the exit command in Mume.
+		Checks if the output indicates any exits that are definitely not hidden despite being flagged as so,
+		then removes any such secret exit from the map.
+		"""
 		if data.startswith("Exits:"):
 			return
 		for line in data.split("\r\n"):

--- a/mapper/cleanmap.py
+++ b/mapper/cleanmap.py
@@ -1,0 +1,26 @@
+﻿# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import re
+
+from .mudevents import Handler
+from .world import DIRECTIONS
+
+directionsRegexp = "|".join([d.title() for d in DIRECTIONS])
+exitRegexp = re.compile(
+	r".*(?<![#(])(?P<dir>" + directionsRegexp + r")(?![#)]).* +- .*"
+)
+
+
+class ExitsCleaner(Handler):
+	def handle(self, data):
+		if data.startswith("Exits:"):
+			return
+		for line in data.split("\r\n"):
+			m = exitRegexp.match(line)
+			if m:
+				room = self.mapper.currentRoom
+				dir = m.group("dir").lower()
+				if self.mapper.isSynced and dir in room.exits and "hidden" in room.exits[dir].doorFlags:
+					self.mapper.user_command_secret("remove " + dir)

--- a/mapper/mapper.py
+++ b/mapper/mapper.py
@@ -1014,7 +1014,7 @@ class Mapper(threading.Thread, World):
 			args = data[len(userCommand):].strip()
 			getattr(self, "user_command_{}".format(decodeBytes(userCommand)))(decodeBytes(args))
 
-	def handleMudData(self, event, data):
+	def handleMudEvent(self, event, data):
 		data = stripAnsi(unescapeXML(decodeBytes(data)))
 		if event in self.mudEventHandlers:
 			if not self.scouting or event in ["iac_ga", "prompt", "movement"]:
@@ -1026,12 +1026,12 @@ class Mapper(threading.Thread, World):
 
 	def registerMudEventHandler(self, event, handler):
 		if event not in self.mudEventHandlers:
-			self.mudEventHandlers[event] = []
-		self.mudEventHandlers[event].append(handler)
+			self.mudEventHandlers[event] = set()
+		self.mudEventHandlers[event].add(handler)
 
 	def deregisterMudEventHandler(self, event, handler):
-		if event in self.mudEventHandlers and handler in self.MudEventHandlers[event]:
-			self.MudEventHandlers[event].remove(handler)
+		if event in self.mudEventHandlers and handler in self.mudEventHandlers[event]:
+			self.mudEventHandlers[event].remove(handler)
 
 	def run(self):
 		while True:
@@ -1045,7 +1045,7 @@ class Mapper(threading.Thread, World):
 				elif dataType == MUD_DATA:
 					# The data was from the mud server.
 					event, data = data
-					self.handleMudData(event, data)
+					self.handleMudEvent(event, data)
 			except Exception as e:
 				self.output("map error")
 				print("error " + str(e))

--- a/mapper/mapper.py
+++ b/mapper/mapper.py
@@ -1027,11 +1027,19 @@ class Mapper(threading.Thread, World):
 			logger.debug("received data with an unknown event type of " + event)
 
 	def registerMudEventHandler(self, event, handler):
+		"""Registers a method to handle mud events of a given type.
+		Params: event, handler
+		where event is the name of the event type, typically corresponding to the XML tag of the incoming data,
+		and handler is a method that takes a single argument, data, which is the text received from the mud.
+		"""
 		if event not in self.mudEventHandlers:
 			self.mudEventHandlers[event] = set()
 		self.mudEventHandlers[event].add(handler)
 
 	def deregisterMudEventHandler(self, event, handler):
+		"""Deregisters mud event handlers.
+		params: same as registerMudEventHandler.
+		"""
 		if event in self.mudEventHandlers and handler in self.mudEventHandlers[event]:
 			self.mudEventHandlers[event].remove(handler)
 

--- a/mapper/mapper.py
+++ b/mapper/mapper.py
@@ -15,6 +15,7 @@ import threading
 from timeit import default_timer
 
 from . import roomdata
+from .cleanmap import ExitsCleaner
 from .clock import (
 	CLOCK_REGEX,
 	TIME_REGEX,
@@ -177,6 +178,7 @@ class Mapper(threading.Thread, World):
 		]:
 			self.registerMudEventHandler(legacyHandler, getattr(self, "mud_event_" + legacyHandler))
 		self.unknownMudEvents = []
+		ExitsCleaner(self, "exits")
 		self.emulationCommands = [
 			func[len("emulation_command_"):] for func in dir(self)
 			if func and func.startswith("emulation_command_") and callable(self.__getattribute__(func))

--- a/mapper/mudevents.py
+++ b/mapper/mudevents.py
@@ -1,0 +1,19 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from abc import ABC, abstractmethod
+
+
+class Handler(ABC):
+	def __init__(self, mapper, event):
+		self.mapper = mapper
+		self.event = event
+		self.mapper.registerMudEventHandler(event, self.handle)
+
+	def __del__(self):
+		self.mapper.deregisterMudEventHandler(self.event, self.handle)
+
+	@abstractmethod
+	def handle(self, data):
+		pass

--- a/mapper/mudevents.py
+++ b/mapper/mudevents.py
@@ -6,14 +6,28 @@ from abc import ABC, abstractmethod
 
 
 class Handler(ABC):
-	def __init__(self, mapper, event):
+	def __init__(self, mapper, event=None):
+		"""Initialises a mud event handler in the given mapper class.
+		params: mapper, event
+		where mapper is the mapper instance that will be dispatching events,
+		and event is an optional event name.
+		The event name may be omitted if the subclass is defined with an event attribute.
+		"""
 		self.mapper = mapper
-		self.event = event
-		self.mapper.registerMudEventHandler(event, self.handle)
+		try:
+			self.event = event or self.event
+		except AttributeError as e:
+			raise ValueError(
+				"Tried to initialise handler without an event type."
+				" Either pass event=MyEventType when initialising, or declare self.event in the class definition."
+			) from e
+		self.mapper.registerMudEventHandler(self.event, self.handle)
 
 	def __del__(self):
-		self.mapper.deregisterMudEventHandler(self.event, self.handle)
+		if hasattr(self, "event"):
+			self.mapper.deregisterMudEventHandler(self.event, self.handle)
 
 	@abstractmethod
 	def handle(self, data):
+		"""the method called when the event is dispatched"""
 		pass

--- a/tests/mapper/test_cleanmap.py
+++ b/tests/mapper/test_cleanmap.py
@@ -1,0 +1,93 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import unittest
+from unittest.mock import Mock
+
+from mapper.cleanmap import DIRECTIONS, ExitsCleaner, exitRegexp
+from mapper.mapper import Mapper
+from mapper.roomdata.objects import Exit, Room
+
+
+class test_exitRegexp(unittest.TestCase):
+	def test_exitsCommandRegexp_matches_allExitsThatAreNeitherOpenNorBrokenDoors(self):
+		for exit in [
+			"[North]  - A closed 'stabledoor'",
+			"South   - The Path over the Bruinen",
+			"[North]  - A closed 'marblegate'",
+			"East    - On a Graceful Bridge",
+			"South   - On a Balcony over the Bruinen",
+			"West    - Meandering Path along the Bruinen",
+			"Up      - At the Last Pavilion",
+			"  [North]   - A closed 'curtain'",
+			"  [East]   - A closed 'curtainthing'",
+			"  [South]   - A closed 'wizardofozcurtain'",
+			" ~[West]~   - A closed 'bedroomcurtain'",
+			" ~[Up]~   - A closed 'DooMDoor'",
+			" ~[Down]~   - A closed 'azZeuZjoec'",
+		]:
+			m = exitRegexp.match(exit)
+			self.assertTrue(m, exit + " does not match the exitRegexp.")
+			dir = m.group("dir").lower()
+			self.assertTrue(
+				dir in DIRECTIONS,
+				dir + " is not a valid direction."
+			)
+
+	def test_exitRegexp_doesNotMatch_exitsThatAreOpenOrBrokenDoors_or_autoexits(self):
+		for exit in [
+			"#South#  - (archedfence) The Summer Terrace",
+			"  (West)  - (door) a room",
+			"None",
+			"Exits: down.",
+			"Exits: north, east, south, west."
+			"Exits: none."
+		]:
+			m = exitRegexp.match(exit)
+			self.assertFalse(m, exit + " should not match the exitRegexp, but it does.")
+
+
+class TestExitsCleaner(unittest.TestCase):
+	def setUp(self):
+		self.mapper = Mock(spec=Mapper)
+		self.mapper.isSynced = True
+		self.exitsCleaner = ExitsCleaner(self.mapper, "exits")
+
+	def createRoom(self, *exits):
+		room = Room("0")
+		for dir, isHidden in exits:
+			if dir not in DIRECTIONS:
+				raise ValueError("Invalid direction " + dir + ". Cannot create room.")
+			room.exits[dir] = Exit()
+			if isHidden:
+				room.exits[dir].doorFlags.add("hidden")
+		return room
+
+	def test_handle_withZeroOrOneExits(self):
+		for room, exit in [
+			(self.createRoom(), "None\r\n"),
+			(self.createRoom(("east", False)), "None\r\n"),
+			(self.createRoom(("south", True)), "None\r\n"),
+			(self.createRoom(), "  (West)   - The Grand Hallway\r\n"),
+			(self.createRoom(("up", False)), "  #Up#   - Private Stair\r\n"),
+			(self.createRoom(("down", True)), "  [east]   - A closed 'EastDoorWhereYouThoughtThereWasADownExit\r\n"),
+			(self.createRoom(), "  [North]   - A closed 'Northdoor'\r\n"),
+			(self.createRoom(("east", False)), "  {East}   - You see something strange.\r\n"),
+			(self.createRoom(), "  /West\\   - Western Slope\r\n"),
+			(self.createRoom(("up", False)), "  Up   - Private Stair\r\n"),
+		]:
+			self.mapper.currentRoom = room
+			self.exitsCleaner.handle(exit)
+			self.mapper.user_command_secret.assert_not_called()
+			self.mapper.user_command_secret.reset_mock()
+
+		for room, exit in [
+			(self.createRoom(("south", True)), "  \\South/   - Southern Slope\r\n"),
+			(self.createRoom(("down", True)), "  *=Down=*   - Public Courtyard\r\n"),
+		]:
+			self.mapper.currentRoom = room
+			dir = exitRegexp.match(exit).group("dir").lower()
+			self.exitsCleaner.handle(exit)
+			self.mapper.user_command_secret.assert_called_once_with("remove " + dir)
+			self.mapper.user_command_secret.reset_mock()

--- a/tests/mapper/test_cleanmap.py
+++ b/tests/mapper/test_cleanmap.py
@@ -52,7 +52,7 @@ class TestExitsCleaner(unittest.TestCase):
 	def setUp(self):
 		self.mapper = Mock(spec=Mapper)
 		self.mapper.isSynced = True
-		self.exitsCleaner = ExitsCleaner(self.mapper, "exits")
+		self.exitsCleaner = ExitsCleaner(self.mapper)
 
 	def createRoom(self, *exits):
 		room = Room("0")
@@ -76,6 +76,7 @@ class TestExitsCleaner(unittest.TestCase):
 			(self.createRoom(("east", False)), "  {East}   - You see something strange.\r\n"),
 			(self.createRoom(), "  /West\\   - Western Slope\r\n"),
 			(self.createRoom(("up", False)), "  Up   - Private Stair\r\n"),
+			(self.createRoom(("down", True)), "Exits: *=Down=*   - Public Courtyard\r\n"),
 		]:
 			self.mapper.currentRoom = room
 			self.exitsCleaner.handle(exit)

--- a/tests/mapper/test_mapper.py
+++ b/tests/mapper/test_mapper.py
@@ -26,7 +26,7 @@ class TestMapper(unittest.TestCase):
 
 	def testMapper_run(self):
 		self.mapper.handleUserData = Mock()
-		self.mapper.handleMudData = Mock()
+		self.mapper.handleMudEvent = Mock()
 		self.mapper.clientSend = Mock()
 		self.mapper.start()
 
@@ -58,14 +58,14 @@ class TestMapper(unittest.TestCase):
 		self.assertEqual(userCalls[2], call(b"not_a_user_command"), "Third handleUserData was not as expected.")
 		self.assertEqual(userCalls[3], call(b"run ingrove"), "Fourth call to handleUserData was not as expected.")
 
-		# validate calls to handleMudData
-		serverCalls = self.mapper.handleMudData.mock_calls
+		# validate calls to handleMudEvent
+		serverCalls = self.mapper.handleMudEvent.mock_calls
 		self.assertEqual(len(serverCalls), 5)
-		self.assertEqual(serverCalls[0], call("line", b"Welcome to mume"), "handleMudData #0 not expected.")
-		self.assertEqual(serverCalls[1], call("prompt", b"hp:hurt mana:burning>"), "Second handleMudData")
-		self.assertEqual(serverCalls[2], call("iac_ga", b""), "Third call to handleMudData")
-		self.assertEqual(serverCalls[3], call("movement", b"east"), "Fourth handleMudData not as expected")
-		self.assertEqual(serverCalls[4], call("not_an_event", b"good bype world"), "Fifth handleMudData")
+		self.assertEqual(serverCalls[0], call("line", b"Welcome to mume"), "handleMudEvent #0 not expected.")
+		self.assertEqual(serverCalls[1], call("prompt", b"hp:hurt mana:burning>"), "Second handleMudEvent")
+		self.assertEqual(serverCalls[2], call("iac_ga", b""), "Third call to handleMudEvent")
+		self.assertEqual(serverCalls[3], call("movement", b"east"), "Fourth handleMudEvent not as expected")
+		self.assertEqual(serverCalls[4], call("not_an_event", b"good bype world"), "Fifth handleMudEvent")
 
 	def testMapper_handleUserData(self):
 		handleUserData = self.mapper.handleUserData
@@ -87,49 +87,73 @@ class TestMapper(unittest.TestCase):
 			with self.assertRaises(AttributeError):
 				self.mapper.handleUserData(command)
 
-	def testMapper_handleMudData(self):
-		for event, data, handlerName, args in [
-			("line", b"Welcome to mume", "mud_event_line", "Welcome to mume"),
-			("dynamic", b"A beautiful room", "mud_event_dynamic", "A beautiful room"),
-			("exits", b"north, east, south", "mud_event_exits", "north, east, south"),
-			("prompt", b"hp:hurt", "mud_event_prompt", "hp:hurt"),
-		]:
-			with patch.object(self.mapper, handlerName) as handler:
-				self.mapper.mudEventHandlers[event] = [handler]
-				self.mapper.handleMudData(event, data)
-				handler.assert_called_with(args)
 
-	def test_handleMudEvent_issuesDebugMessageWhenTryingToHandleAnUnregisteredEvent(self):
+class TestMapper_handleMudEvent(unittest.TestCase):
+	def setUp(self):
+		Mapper.loadRooms = Mock()  # to speed execution of tests
+		self.legacyHandlerNames = [
+			handlerName for handlerName in dir(Mapper)
+			if handlerName.startswith("mud_event_") and callable(getattr(Mapper, handlerName))
+		]
+		for handlerName in self.legacyHandlerNames:
+			setattr(Mapper, handlerName, Mock())
+		self.mapper = Mapper(
+			client=Mock(),
+			server=None,
+			outputFormat=None,
+			interface="text",
+			promptTerminator=None,
+			gagPrompts=None,
+			findFormat=None,
+			isEmulatingOffline=None,
+		)
+		self.mapper.daemon = True  # this allows unittest to quit if the mapper thread does not close properly.
+
+	def test_legacyMudEventHandlers(self):
+		events = [handlerName[len("mud_event_"):] for handlerName in self.legacyHandlerNames]
+		handlers = [getattr(self.mapper, handlerName) for handlerName in self.legacyHandlerNames]
+		for event, handler in zip(events, handlers):
+			sampleInput1 = b"Helol oje"
+			sampleInput2 = b"no sir, away. a papaya war is on"
+			sampleInput3 = b"delting no sir, away. a papaya war is on"
+			self.mapper.registerMudEventHandler(event, handler)
+			self.mapper.handleMudEvent(event, sampleInput1)
+			handler.assert_called_once_with(str(sampleInput1, "US-ASCII"))
+			handler.reset_mock()
+			self.mapper.handleMudEvent(event, sampleInput2)
+			handler.assert_called_once_with(str(sampleInput2, "US-ASCII"))
+			handler.reset_mock()
+			self.mapper.deregisterMudEventHandler(event, handler)
+			self.mapper.handleMudEvent(event, sampleInput3)
+			handler.assert_not_called()
+
+	def test_newMudEventHandlers(self):
+		for event in [
+			"sillyEvent",
+			"room",
+			"otherEvent",
+		]:
+			handler = Mock()
+			sampleInput1 = b"Helol oje"
+			sampleInput2 = b"no sir, away. a papaya war is on"
+			sampleInput3 = b"delting no sir, away. a papaya war is on"
+			self.mapper.registerMudEventHandler(event, handler)
+			self.mapper.handleMudEvent(event, sampleInput1)
+			handler.assert_called_once_with(str(sampleInput1, "US-ASCII"))
+			handler.reset_mock()
+			self.mapper.handleMudEvent(event, sampleInput2)
+			handler.assert_called_once_with(str(sampleInput2, "US-ASCII"))
+			handler.reset_mock()
+			self.mapper.deregisterMudEventHandler(event, handler)
+			self.mapper.handleMudEvent(event, sampleInput3)
+			handler.assert_not_called()
+
+	def test_handleMudEvent_failsGracefullyWhenHandlingAnUnknownEvent(self):
 		for unknownEvent in [
 			"unkk",
 			"New_game_event",
 			"room",
 			"<interesting-tag-<in>-a-tag>",
 		]:
-			self.assertFalse(unknownEvent in self.mapper.unknownMudEvents)
-			self.mapper.handleMudData(unknownEvent, "meaningless input")
-			self.assertTrue(unknownEvent in self.mapper.unknownMudEvents)
-
-	def test_init_RegistersLegacyHandlers(self):
-		legacyHandlers = [
-			getattr(self.mapper, handlerName) for handlerName in dir(self.mapper)
-			if handlerName.startswith("mud_event_") and callable(getattr(self.mapper, handlerName))
-		]
-		for event in self.mapper.mudEventHandlers:
-			for handler in self.mapper.mudEventHandlers[event]:
-				if handler in legacyHandlers:
-					legacyHandlers.remove(handler)
-		self.assertFalse(legacyHandlers)
-
-	def test_registerMudEventHandler_addsTheHandler(self):
-		for event, sampleInput in [
-			("sillyEvent", b"hello world"),
-			("room", b"We start playing a game"),
-			("otherEvent", b"<unknown>mystery</unknown>"),
-		]:
-			handler = Mock()
-			self.mapper.registerMudEventHandler(event, handler)
-			self.assertTrue(event in self.mapper.mudEventHandlers)
-			self.assertTrue(handler in self.mapper.mudEventHandlers[event])
-			self.mapper.handleMudData(event, sampleInput)
-			handler.assert_called_with(str(sampleInput, "US-ASCII"))
+			self.mapper.handleMudEvent(unknownEvent, "meaningless input")
+			# simply require this to execute without raising an exception

--- a/tests/mapper/test_mudevents.py
+++ b/tests/mapper/test_mudevents.py
@@ -1,0 +1,44 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import unittest
+from unittest.mock import Mock
+
+from mapper.mapper import Mapper
+from mapper.mudevents import Handler
+
+
+class DummieHandler(Handler):
+	def handle(self, data):
+		self.mapper.queue.put("I received " + data)
+
+
+class TestHandler(unittest.TestCase):
+	def setUp(self):
+		Mapper.loadRooms = Mock()  # to speed execution of tests
+		self.mapper = Mapper(
+			client=None,
+			server=None,
+			outputFormat=None,
+			interface="text",
+			promptTerminator=None,
+			gagPrompts=None,
+			findFormat=None,
+			isEmulatingOffline=None,
+		)
+		self.mapper.daemon = True  # this allows unittest to quit if the mapper thread does not close properly.
+
+	def testMapper_handle(self):
+		queue = self.mapper.queue
+		queue.put = Mock()
+		dummieHandler = DummieHandler(self.mapper, "testEvent")
+		self.mapper.handleMudEvent("testEvent", b"Hello world")
+		queue.put.assert_called_once_with("I received Hello world")
+		queue.put.reset_mock()
+		self.mapper.handleMudEvent("testEvent", b"I am here.")
+		queue.put.assert_called_once_with("I received I am here.")
+		queue.put.reset_mock()
+		dummieHandler.__del__()
+		self.mapper.handleMudEvent("testEvent", b"Goodbye world")
+		queue.put.assert_not_called()

--- a/tests/mapper/test_mudevents.py
+++ b/tests/mapper/test_mudevents.py
@@ -10,8 +10,15 @@ from mapper.mudevents import Handler
 
 
 class DummieHandler(Handler):
+	event = "testEvent"
+
 	def handle(self, data):
 		self.mapper.queue.put("I received " + data)
+
+
+class HandlerWithoutType(Handler):
+	def handle(self, data):
+		pass
 
 
 class TestHandler(unittest.TestCase):
@@ -32,13 +39,19 @@ class TestHandler(unittest.TestCase):
 	def testMapper_handle(self):
 		queue = self.mapper.queue
 		queue.put = Mock()
-		dummieHandler = DummieHandler(self.mapper, "testEvent")
-		self.mapper.handleMudEvent("testEvent", b"Hello world")
+		dummieHandler = DummieHandler(self.mapper)
+
+		self.mapper.handleMudEvent(dummieHandler.event, b"Hello world")
 		queue.put.assert_called_once_with("I received Hello world")
 		queue.put.reset_mock()
+
 		self.mapper.handleMudEvent("testEvent", b"I am here.")
 		queue.put.assert_called_once_with("I received I am here.")
 		queue.put.reset_mock()
+
 		dummieHandler.__del__()
 		self.mapper.handleMudEvent("testEvent", b"Goodbye world")
 		queue.put.assert_not_called()
+
+	def test_init_raisesValueErrorWhenNoEventTypeIsProvided(self):
+		self.assertRaises(ValueError, HandlerWithoutType, self.mapper)


### PR DESCRIPTION
Refactor mapper.py to use an event-based architecture for handling data from the mud.

Add cleanmap.py as a sample of how to code and install event handlers