### PR TITLE
Wordwrap

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -38,7 +38,7 @@ exclude =
 	__pycache__,
 	env/
 	maps/
-	tests\mapper\protocols\test_*paragraphs.py
+	tests\mapper\protocols\test_sample_texts.py
 
 filename =
 	*.py,

--- a/.flake8
+++ b/.flake8
@@ -38,6 +38,7 @@ exclude =
 	__pycache__,
 	env/
 	maps/
+	tests\mapper\protocols\test_*paragraphs.py
 
 filename =
 	*.py,

--- a/.flake8
+++ b/.flake8
@@ -36,6 +36,8 @@ exclude =
 	venv,
 	ENV,
 	__pycache__,
+	env/
+	maps/
 
 filename =
 	*.py,

--- a/mapper/mapper.py
+++ b/mapper/mapper.py
@@ -521,6 +521,13 @@ class Mapper(threading.Thread, World):
 	def user_command_doorflags(self, *args: str) -> None:
 		self.sendPlayer(self.doorflags(*args))
 
+	def user_command_wordwrap(self, *args: str) -> None:
+		cfg: Config = Config()
+		wordwrap = not cfg.get("wordwrap", True)
+		self.sendPlayer(f"wordwrap {'enabled' if wordwrap else 'disabled'}")
+		cfg["wordwrap"] = wordwrap
+		cfg.save()
+
 	def user_command_secret(self, *args: str) -> None:
 		self.sendPlayer(self.secret(*args))
 

--- a/mapper/protocols/mpi.py
+++ b/mapper/protocols/mpi.py
@@ -228,10 +228,14 @@ class MPIProtocol(Protocol):
 		super().on_dataReceived(MPI_INIT + command + b"%d" % len(data) + LF + data)
 
 	def postprocess(self, text: str) -> str:
+		# replace consecutive newlines with a null placeholder
+		text = re.sub(r"\n(\s*\n)+", "\0", text)
 		# collapse all runs of whitespace into a single space
 		text = re.sub(r"\s+", " ", text.strip())
 		# capitaalise beginnings of sentences
 		text = ". ".join([sentence.capitalize() for sentence in text.split(". ")])
+		# reinsert consecutive newlines
+		text = text.replace("\0", "\n\n")
 		# wordwrap to 80 chars
 		text = textwrap.fill(
 			text, width=79, drop_whitespace=True, break_long_words=False, break_on_hyphens=False

--- a/mapper/protocols/mpi.py
+++ b/mapper/protocols/mpi.py
@@ -260,11 +260,11 @@ class MPIProtocol(Protocol):
 
 	def collapseSpaces(self, text: str) -> str:
 		# replace consecutive newlines with a null placeholder
-		text = re.sub(r"\n(\s*\n)+", "\0", text)
+		text = text.replace("\n", "\0")
 		# collapse all runs of whitespace into a single space
-		text = re.sub(r"\s+", " ", text.strip())
+		text = re.sub(r"[ \t]+", " ", text.strip())
 		# reinsert consecutive newlines
-		text = text.replace("\0", "\n\n")
+		text = text.replace("\0", "\n")
 		return text
 
 	def capitalise(self, text: str) -> str:

--- a/mapper/protocols/mpi.py
+++ b/mapper/protocols/mpi.py
@@ -228,7 +228,11 @@ class MPIProtocol(Protocol):
 		super().on_dataReceived(MPI_INIT + command + b"%d" % len(data) + LF + data)
 
 	def postprocess(self, text: str) -> str:
+		# collapse all runs of whitespace into a single space
 		text = re.sub(r"\s+", " ", text.strip())
+		# capitaalise beginnings of sentences
+		text = ". ".join([sentence.capitalize() for sentence in text.split(". ")])
+		# wordwrap to 80 chars
 		text = textwrap.fill(
 			text, width=79, drop_whitespace=True, break_long_words=False, break_on_hyphens=False
 		)

--- a/mapper/protocols/mpi.py
+++ b/mapper/protocols/mpi.py
@@ -232,16 +232,24 @@ class MPIProtocol(Protocol):
 		super().on_dataReceived(MPI_INIT + command + b"%d" % len(data) + LF + data)
 
 	def postprocess(self, text: str) -> str:
+		text = self.collapseSpaces(text)
+		text = self.capitalise(text)
+		text = self.wordwrap(text)
+		return text
+
+	def collapseSpaces(self, text: str) -> str:
 		# replace consecutive newlines with a null placeholder
 		text = re.sub(r"\n(\s*\n)+", "\0", text)
 		# collapse all runs of whitespace into a single space
 		text = re.sub(r"\s+", " ", text.strip())
-		# capitaalise beginnings of sentences
-		text = ". ".join([sentence.capitalize() for sentence in text.split(". ")])
 		# reinsert consecutive newlines
 		text = text.replace("\0", "\n\n")
-		# wordwrap to 80 chars
-		text = textwrap.fill(
+		return text
+
+	def capitalise(self, text: str) -> str:
+		return ". ".join([sentence.capitalize() for sentence in text.split(". ")])
+
+	def wordwrap(self, text: str) -> str:
+		return textwrap.fill(
 			text, width=79, drop_whitespace=True, break_long_words=False, break_on_hyphens=False
 		)
-		return text

--- a/tests/mapper/protocols/test_mpi.py
+++ b/tests/mapper/protocols/test_mpi.py
@@ -260,3 +260,15 @@ class TestEditorPostprocessor(TestCase):
 					80,
 					f"The line\n{line}\nfrom the paragraph\n{paragraph}\nis {len(line)} chars long, which is too long",
 				)
+			# test preservation of runs of newlines
+			startLineCount = len(
+				[line for line in paragraph.strip().split("\n") if line.isspace() or not len(line)]
+			)
+			processedLineCount = len(
+				[line for line in processedParagraph.strip().split("\n") if not len(line)]
+			)
+			self.assertEqual(
+				startLineCount,
+				processedLineCount,
+				f"These paragraphs have {startLineCount} and {processedLineCount} runs of newlines, respectively.\nFirst paragraph:\n{paragraph}\n\nSecond paragraph:\n{processedParagraph}",  # noqa E501
+			)

--- a/tests/mapper/protocols/test_mpi.py
+++ b/tests/mapper/protocols/test_mpi.py
@@ -244,9 +244,16 @@ class TestEditorPostprocessor(TestCase):
 			self.gameReceives.extend, self.playerReceives.extend, outputFormat="normal"
 		).postprocess
 
-	def test_whenClosingEditor_linesAreWordwrappedTo80chars(self) -> None:
+	def test_postprocessing(self) -> None:
 		for paragraph in paragraphs:
 			processedParagraph: str = self.postprocess(paragraph)
+			# test capitalisation
+		for sentence in processedParagraph.split(". "):
+			self.assertTrue(
+				sentence[0].isupper() or not sentence[0].isalpha(),
+				f"The sentence\n{sentence}\nfrom the paragraph\n{paragraph}\nstarts with an uncapitalized letter.",
+			)
+			# test wordwrapping
 			for line in processedParagraph.split("\n"):
 				self.assertLess(
 					len(line),

--- a/tests/mapper/protocols/test_mpi.py
+++ b/tests/mapper/protocols/test_mpi.py
@@ -283,17 +283,13 @@ class TestEditorPostprocessor(TestCase):
 			)
 			subfunctionsMock.reset_mock()
 
-	def test_whenCollapsingSpaces_thenRunsOfNewlinesArePreserved(self) -> None:
+	def test_whenCollapsingSpaces_thenEachNewlineIsPreserved(self) -> None:
 		for sampleText in sampleTexts:
 			processedText: str = self.collapseSpaces(sampleText)
-			startLineCount = len(
-				[line for line in sampleText.strip().split("\n") if line.isspace() or not len(line)]
-			)
-			processedLineCount = len([line for line in processedText.strip().split("\n") if not len(line)])
 			self.assertEqual(
-				startLineCount,
-				processedLineCount,
-				f"These texts have {startLineCount} and {processedLineCount} runs of newlines, respectively.\nsample text:\n{sampleText}\n\nprocessed text:\n{processedText}",  # noqa E501
+				processedText.count("\n"),
+				sampleText.count("\n"),
+				f"processed text:\n{processedText}\nsample text:\n{sampleText}\n",
 			)
 
 	def test_capitalisation(self) -> None:

--- a/tests/mapper/protocols/test_mpi.py
+++ b/tests/mapper/protocols/test_mpi.py
@@ -258,27 +258,16 @@ class TestEditorPostprocessor(TestCase):
 	def setUp(self) -> None:
 		self.gameReceives: bytearray = bytearray()
 		self.playerReceives: bytearray = bytearray()
-		self.postprocess = MPIProtocol(
+		self.MPIProtocol = MPIProtocol(
 			self.gameReceives.extend, self.playerReceives.extend, outputFormat="normal"
-		).postprocess
+		)
+		self.collapseSpaces = self.MPIProtocol.collapseSpaces
+		self.capitalise = self.MPIProtocol.capitalise
+		self.wordwrap = self.MPIProtocol.wordwrap
 
-	def test_postprocessing(self) -> None:
+	def test_whenCollapsingSpaces_thenRunsOfNewlinesArePreserved(self) -> None:
 		for paragraph in paragraphs:
-			processedParagraph: str = self.postprocess(paragraph)
-			# test capitalisation
-		for sentence in processedParagraph.split(". "):
-			self.assertTrue(
-				sentence[0].isupper() or not sentence[0].isalpha(),
-				f"The sentence\n{sentence}\nfrom the paragraph\n{paragraph}\nstarts with an uncapitalized letter.",
-			)
-			# test wordwrapping
-			for line in processedParagraph.split("\n"):
-				self.assertLess(
-					len(line),
-					80,
-					f"The line\n{line}\nfrom the paragraph\n{paragraph}\nis {len(line)} chars long, which is too long",
-				)
-			# test preservation of runs of newlines
+			processedParagraph: str = self.collapseSpaces(paragraph)
 			startLineCount = len(
 				[line for line in paragraph.strip().split("\n") if line.isspace() or not len(line)]
 			)
@@ -290,3 +279,22 @@ class TestEditorPostprocessor(TestCase):
 				processedLineCount,
 				f"These paragraphs have {startLineCount} and {processedLineCount} runs of newlines, respectively.\nFirst paragraph:\n{paragraph}\n\nSecond paragraph:\n{processedParagraph}",  # noqa E501
 			)
+
+	def test_capitalisation(self) -> None:
+		for paragraph in paragraphs:
+			processedParagraph: str = self.capitalise(paragraph)
+		for sentence in processedParagraph.split(". "):
+			self.assertTrue(
+				sentence[0].isupper() or not sentence[0].isalpha(),
+				f"The sentence\n{sentence}\nfrom the paragraph\n{paragraph}\nstarts with an uncapitalized letter.",
+			)
+
+	def test_wordwrap(self) -> None:
+		for paragraph in paragraphs:
+			processedParagraph: str = self.wordwrap(paragraph)
+			for line in processedParagraph.split("\n"):
+				self.assertLess(
+					len(line),
+					80,
+					f"The line\n{line}\nfrom the paragraph\n{paragraph}\nis {len(line)} chars long, which is too long",
+				)

--- a/tests/mapper/protocols/test_mpi.py
+++ b/tests/mapper/protocols/test_mpi.py
@@ -17,7 +17,7 @@ from mapper.protocols.mpi import MPI_INIT, MPIProtocol
 from mapper.protocols.telnet_constants import LF
 
 # Local Modules:
-from .test_paragraphs import paragraphs
+from .test_sample_texts import sampleTexts
 
 
 BODY: bytes = b"Hello World!"
@@ -266,35 +266,33 @@ class TestEditorPostprocessor(TestCase):
 		self.wordwrap = self.MPIProtocol.wordwrap
 
 	def test_whenCollapsingSpaces_thenRunsOfNewlinesArePreserved(self) -> None:
-		for paragraph in paragraphs:
-			processedParagraph: str = self.collapseSpaces(paragraph)
+		for sampleText in sampleTexts:
+			processedText: str = self.collapseSpaces(sampleText)
 			startLineCount = len(
-				[line for line in paragraph.strip().split("\n") if line.isspace() or not len(line)]
+				[line for line in sampleText.strip().split("\n") if line.isspace() or not len(line)]
 			)
-			processedLineCount = len(
-				[line for line in processedParagraph.strip().split("\n") if not len(line)]
-			)
+			processedLineCount = len([line for line in processedText.strip().split("\n") if not len(line)])
 			self.assertEqual(
 				startLineCount,
 				processedLineCount,
-				f"These paragraphs have {startLineCount} and {processedLineCount} runs of newlines, respectively.\nFirst paragraph:\n{paragraph}\n\nSecond paragraph:\n{processedParagraph}",  # noqa E501
+				f"These texts have {startLineCount} and {processedLineCount} runs of newlines, respectively.\nsample text:\n{sampleText}\n\nprocessed text:\n{processedText}",  # noqa E501
 			)
 
 	def test_capitalisation(self) -> None:
-		for paragraph in paragraphs:
-			processedParagraph: str = self.capitalise(paragraph)
-		for sentence in processedParagraph.split(". "):
+		for sampleText in sampleTexts:
+			processedText: str = self.capitalise(sampleText)
+		for sentence in processedText.split(". "):
 			self.assertTrue(
 				sentence[0].isupper() or not sentence[0].isalpha(),
-				f"The sentence\n{sentence}\nfrom the paragraph\n{paragraph}\nstarts with an uncapitalized letter.",
+				f"The sentence\n{sentence}\nfrom the sample text\n{sampleText}\nstarts with an uncapitalized letter.",
 			)
 
 	def test_wordwrap(self) -> None:
-		for paragraph in paragraphs:
-			processedParagraph: str = self.wordwrap(paragraph)
-			for line in processedParagraph.split("\n"):
+		for sampleText in sampleTexts:
+			processedText: str = self.wordwrap(sampleText)
+			for line in processedText.split("\n"):
 				self.assertLess(
 					len(line),
 					80,
-					f"The line\n{line}\nfrom the paragraph\n{paragraph}\nis {len(line)} chars long, which is too long",
+					f"The line\n{line}\nfrom the sample text\n{sampleText}\nis {len(line)} chars long, which is too long",
 				)

--- a/tests/mapper/protocols/test_paragraphs.py
+++ b/tests/mapper/protocols/test_paragraphs.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 paragraphs: list[str] = [
 	"",
+	".",
+	"..",
+	"....",
 	"\n",
 	"\n\n",
 	"\\t  \t \n \n",

--- a/tests/mapper/protocols/test_paragraphs.py
+++ b/tests/mapper/protocols/test_paragraphs.py
@@ -1,0 +1,30 @@
+# Future Modules:
+from __future__ import annotations
+
+
+paragraphs: list[str] = [
+	"",
+	"\n",
+	"\n\n",
+	"\\t  \t \n \n",
+	"""Long, wavey strands of grass flutter over the tops of wildly growing crops. A
+barren, rocky ridge rises southwards, casting a long, pointed shadow over this
+field. A decrepit stone wall appears to have been built over what was once the
+tail end of the ridge, but has now been reduced to little more than a bump in
+the field. To the east and north, the field continues, while in the west it
+comes to an abrupt end at an erradic line of scattered rocks and clumps of
+dirt.
+	""",
+	"A round clearing, Measuring the length of a bow shot from one side to the other, is neatly trimmed out of a circle of hedges In the middle, the grass and soil, in turn, give way to a balding patch of rock swelling up from the Earth. Uncovered to the heights of the sky, the swelling mound peaks at an unusual shrine of stones that look as if they naturally grew out of the mound itself. Green, flowering ivy clothes the shrine, and drapes down the crevices in the rock like long, elaborate braids. Where the mound comes level with the clearing, a circle of majestic trees rises above, crowning the mound with a green ring of broad leaves.",  # noqa E511
+	"""A lightly wooded hill divides the Bree forest in the east from the 
+road to
+Fornost in the west. Not quite rising to the heights of
+ the trees at the base of the hill, this hill offers little view other than a passing glimps of those
+travelling the road directly to the west. Beyond the road, rising above 
+the tree canapy, a barren ridge forms a straight line across the horizon. Remnents
+of food stuffs and miscellaneous trifles are scattered around the hilltop,
+although no sign of habitation can be seen.
+	""",
+	"""living thing protrudes. In the south, the ground continues without change before falling down to yet more fields, while in the west, the ground levels
+	""",
+]

--- a/tests/mapper/protocols/test_sample_texts.py
+++ b/tests/mapper/protocols/test_sample_texts.py
@@ -9,7 +9,7 @@ sampleTexts: list[str] = [
 	"....",
 	"\n",
 	"\n\n",
-	"\\t  \t \n \n",
+	"\t  \t \n \n",
 	"""Long, wavey strands of grass flutter over the tops of wildly growing crops. A
 barren, rocky ridge rises southwards, casting a long, pointed shadow over this
 field. A decrepit stone wall appears to have been built over what was once the
@@ -29,5 +29,33 @@ of food stuffs and miscellaneous trifles are scattered around the hilltop,
 although no sign of habitation can be seen.
 	""",
 	"""living thing protrudes. In the south, the ground continues without change before falling down to yet more fields, while in the west, the ground levels
+	""",
+	"#",
+	"#x.",
+	"  #x.",
+	"..\n#x",
+	"#x\ny",
+	"\nt\n",
+	"A\nB\n#C\n#d\ne\nf\ng\n#h\#i\j",
+	"A\nB\nC\n#d\n#e\nf\g\#h\#i\j",
+	"""Long, wavey strands of grass flutter over the tops of wildly growing crops. A
+barren, rocky ridge rises southwards, casting a long, pointed shadow over this
+#* eat food
+# you eat the mushroom
+field. A decrepit stone wall appears to have been built over what was once the
+tail end of the ridge, but has now been reduced to little more than a bump in
+the field. To the east and north, the field continues, while in the west it
+comes to an abrupt end at an erradic line of scattered rocks and clumps of
+dirt.
+	""",
+	"A round clearing, Measuring the length of a bow shot from one side to the other, is neatly trimmed out of a circle of hedges In the middle, the grass and soil, in turn, give way to a balding patch of rock swelling up from the Earth. Uncovered to the heights of the sky, the swelling mound peaks at an unusual shrine of stones that look as if they naturally grew out of the mound itself. Green, flowering ivy clothes the shrine, and drapes down the crevices in the rock like long, elaborate braids. Where the mound comes level with the clearing, a circle of majestic trees rises above, crowning the mound with a green ring of broad leaves.",  # noqa E511
+	"""A lightly wooded hill divides the Bree forest in the east from the 
+road to
+Fornost in the west. Not quite rising to the heights of
+# comment  the trees at the base of the hill, this hill offers little view other than a passing glimps of those
+travelling the road directly to the west. Beyond the road, rising above 
+the tree canapy, a barren ridge forms a straight line across the horizon. Remnents
+# another comment of food stuffs and miscellaneous trifles are scattered around the hilltop,
+although no sign of habitation can be seen.
 	""",
 ]

--- a/tests/mapper/protocols/test_sample_texts.py
+++ b/tests/mapper/protocols/test_sample_texts.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 
-paragraphs: list[str] = [
+sampleTexts: list[str] = [
 	"",
 	".",
 	"..",


### PR DESCRIPTION
Add support for wordwrapping text entered in the external editor to the standard Mume terminal width of 80 characters.

On closing the external editor:
- all runs of whitespace are replaced by a single space, except runs containing multiple newlines, which are replaced by two consecutive newlines acting as a paragraph break
- - The first letter of every sentence is capitalised
- - remaining text is word-wrapped to lines of 80 characters or less while respecting any paragraph breaks
 
Adding a number sign "#" before the first non-whitespace character on a line disables this functionality for that line.

All this behavior can be toggled with the user command "wordwrap".